### PR TITLE
商品削除機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,6 @@
 class ItemsController < ApplicationController
   
-  before_action :authenticate_user!, except: [:index, :show, :destroy]
+  before_action :authenticate_user!, except: [:index, :show]
   before_action :set_item, only: [:show,:edit, :update, :destroy]
 
   def index

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,7 +1,7 @@
 class ItemsController < ApplicationController
   
-  before_action :authenticate_user!, except: [:index, :show]
-  before_action :set_item, only: [:show,:edit, :update]
+  before_action :authenticate_user!, except: [:index, :show, :destroy]
+  before_action :set_item, only: [:show,:edit, :update, :destroy]
 
   def index
     @items = Item.all.order(created_at: :desc)
@@ -28,6 +28,11 @@ class ItemsController < ApplicationController
         render :edit, status: :unprocessable_entity
       end
   end
+
+  def destroy
+    @item.destroy
+    redirect_to action: :index
+  end
   
     def create
       @item = Item.new(item_params)
@@ -38,8 +43,6 @@ class ItemsController < ApplicationController
       render :new, status: :unprocessable_entity
     end
   end
-    end
-
 
   private
   
@@ -50,3 +53,4 @@ class ItemsController < ApplicationController
   def set_item
     @item = Item.find(params[:id])
   end
+end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -30,9 +30,13 @@ class ItemsController < ApplicationController
   end
 
   def destroy
+    if current_user.id == item.user.id
     @item.destroy
     redirect_to action: :index
+  else
+    redirect_to root_path
   end
+end
   
     def create
       @item = Item.new(item_params)

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -27,7 +27,7 @@
 
     <%= link_to "商品の編集", edit_item_path(@item.id), method: :get, class: "item-red-btn" %>
     <p class="or-text">or</p>
-    <%= link_to "削除", "#", data: {turbo_method: :delete}, class:"item-destroy" %>
+    <%= link_to "削除", item_path(@item.id), data: { turbo_method: :delete }, class:"item-destroy" %>
 
 <% end %>
       


### PR DESCRIPTION
WHAT
フリマアプリにおいて必須機能の
商品削除機能の作成
WHY
不要になった商品ページを削除する為

ログイン状態の出品者のみ、詳細ページの削除ボタンを押すと、出品した商品を削除できる動画
https://gyazo.com/552ee9bb82dd173f816c6fdbf60df2b5